### PR TITLE
Fix Spelling Error In Template

### DIFF
--- a/apps/fido/templates/authenticate.html
+++ b/apps/fido/templates/authenticate.html
@@ -21,7 +21,7 @@
 {% block Content %}
 
 
-  <h1>Authenticate with yout device</h1>
+  <h1>Authenticate with your device</h1>
   <p>Touch your authenticator device now...</p>
   <hr>
 


### PR DESCRIPTION
#87

This pull request fixes the spelling error in the `apps/fido/templates/authenticate.html` template.