### PR TITLE
Limit allowed grant types through settings

### DIFF
--- a/apps/oidc/test_request_validator.py
+++ b/apps/oidc/test_request_validator.py
@@ -143,7 +143,7 @@ class RequestValidatorTests(TestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        self.assertIn("id_token", response["Location"])
+        self.assertIn("error", response["Location"])
 
     def test_id_token_only_implicit_works(self):
         """
@@ -166,4 +166,4 @@ class RequestValidatorTests(TestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        self.assertIn("id_token", response["Location"])
+        self.assertIn("error", response["Location"])

--- a/libs/grant_types_validator.py
+++ b/libs/grant_types_validator.py
@@ -1,0 +1,25 @@
+from oauth2_provider.oauth2_validators import OAuth2Validator as ParentValidator
+from oauthlib.oauth2 import InvalidGrantError
+from django.conf import settings
+
+class SettingsFlowValidatorMixin(object):
+    def validate_grant_type(self, client_id, grant_type, client, request, *args, **kwargs):
+        """
+        Validate grant_type is whitelisted in django settings
+        """
+        try:
+            assert(grant_type in settings.OAUTH2_PROVIDER_ALLOWED_GRANT_TYPES)
+        except AssertionError:
+            return False
+        return super().validate_grant_type(client_id, grant_type, client, request, *args, **kwargs)
+
+    def validate_response_type(self, client_id, response_type, client, request, *args, **kwargs):
+        try:
+            assert(response_type in settings.OAUTH2_PROVIDER_ALLOWED_RESPONSE_TYPES)
+        except AssertionError:
+            return False
+        return super().validate_response_type(client_id, response_type, client, request, *args, **kwargs)
+
+
+class OAuth2Validator(SettingsFlowValidatorMixin, ParentValidator):
+    pass

--- a/libs/grant_types_validator.py
+++ b/libs/grant_types_validator.py
@@ -1,6 +1,6 @@
 from oauth2_provider.oauth2_validators import OAuth2Validator as ParentValidator
-from oauthlib.oauth2 import InvalidGrantError
 from django.conf import settings
+
 
 class SettingsFlowValidatorMixin(object):
     def validate_grant_type(self, client_id, grant_type, client, request, *args, **kwargs):

--- a/templates/oauth2_provider/application_form.html
+++ b/templates/oauth2_provider/application_form.html
@@ -1,0 +1,41 @@
+{% extends "oauth2_provider/base.html" %}
+
+{% load i18n %}
+{% block content %}
+    <div class="block-center">
+        <form class="form-horizontal" method="post" action="{% block app-form-action-url %}{% url 'oauth2_provider:update' application.id %}{% endblock app-form-action-url %}">
+            <h3 class="block-center-heading">
+                {% block app-form-title %}
+                    {% trans "Edit application" %} {{ application.name }}
+                {% endblock app-form-title %}
+            </h3>
+            {% csrf_token %}
+            {% for field in form %}
+                <div class="control-group {% if field.errors %}error{% endif %}">
+                    <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                    <div class="controls">
+                        {{ field }}
+                        {% for error in field.errors %}
+                            <span class="help-inline">{{ error }}</span>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+
+            <div class="control-group {% if form.non_field_errors %}error{% endif %}">
+                {% for error in form.non_field_errors %}
+                    <span class="help-inline">{{ error }}</span>
+                {% endfor %}
+            </div>
+
+            <div class="control-group">
+                <div class="controls">
+                    <a class="btn" href="{% block app-form-back-url %}{% url "oauth2_provider:detail" application.id %}{% endblock app-form-back-url %}">
+                        {% trans "Go Back" %}
+                    </a>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/vmi/oauth2_validators.py
+++ b/vmi/oauth2_validators.py
@@ -1,0 +1,7 @@
+from apps.oidc.request_validator import RequestValidator as OIDCRequestValidator
+from libs.grant_types_validator import SettingsFlowValidatorMixin
+
+
+class RequestValidator(SettingsFlowValidatorMixin,
+                       OIDCRequestValidator):
+    pass

--- a/vmi/oauth2_views.py
+++ b/vmi/oauth2_views.py
@@ -1,8 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django import forms
-from django.urls import reverse_lazy
 from django.views.generic import (
-    CreateView, DeleteView, DetailView, ListView, UpdateView
+    CreateView,
 )
 
 from oauth2_provider.models import get_application_model
@@ -14,13 +13,12 @@ class ApplicationForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        instance = getattr(self, 'instance', None)
         self.fields['client_id'].disabled = True
         self.fields['client_secret'].disabled = True
 
     class Meta:
         model = get_application_model()
-        fields=(
+        fields = (
             "name", "client_id", "client_secret", "client_type",
             "authorization_grant_type", "redirect_uris"
         )

--- a/vmi/oauth2_views.py
+++ b/vmi/oauth2_views.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django import forms
+from django.urls import reverse_lazy
+from django.views.generic import (
+    CreateView, DeleteView, DetailView, ListView, UpdateView
+)
+
+from oauth2_provider.models import get_application_model
+
+
+class ApplicationForm(forms.ModelForm):
+    client_type = forms.CharField(initial="confidential", disabled=True)
+    authorization_grant_type = forms.CharField(initial="authorization-code", disabled=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        instance = getattr(self, 'instance', None)
+        self.fields['client_id'].disabled = True
+        self.fields['client_secret'].disabled = True
+
+    class Meta:
+        model = get_application_model()
+        fields=(
+            "name", "client_id", "client_secret", "client_type",
+            "authorization_grant_type", "redirect_uris"
+        )
+
+
+class ApplicationRegistration(LoginRequiredMixin, CreateView):
+    template_name = "oauth2_provider/application_registration_form.html"
+    form_class = ApplicationForm
+
+    def form_valid(self, form):
+        form.instance.user = self.request.user
+        return super().form_valid(form)

--- a/vmi/settings.py
+++ b/vmi/settings.py
@@ -171,7 +171,7 @@ REST_FRAMEWORK = {
 OAUTH2_PROVIDER = {
     'SCOPES': {'openid': 'open id connect access'},
     'DEFAULT_SCOPES': ['openid'],
-    'OAUTH2_VALIDATOR_CLASS': 'apps.oidc.request_validator.RequestValidator',
+    'OAUTH2_VALIDATOR_CLASS': 'vmi.oauth2_validators.RequestValidator',
     'OAUTH2_SERVER_CLASS': 'apps.oidc.server.Server',
     'REQUEST_APPROVAL_PROMPT': 'auto',
 }
@@ -179,6 +179,16 @@ OAUTH2_PROVIDER_GRANT_MODEL = 'oidc.Grant'
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = 'oauth2_provider.AccessToken'
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL = 'oauth2_provider.RefreshToken'
+OAUTH2_PROVIDER_ALLOWED_GRANT_TYPES = (
+    "authorization_code",
+    # "password",
+    # "client_credentials",
+    "refresh_token",
+)
+OAUTH2_PROVIDER_ALLOWED_RESPONSE_TYPES = (
+    # "token",
+    "code",
+)
 OIDC_PROVIDER = {
     # 'OIDC_ISSUER': 'http://localhost:8000',
     'OIDC_BASE_CLAIM_PROVIDER_CLASS': 'apps.oidc.claims.ClaimProvider',

--- a/vmi/urls.py
+++ b/vmi/urls.py
@@ -20,6 +20,7 @@ from django.urls import (
 )
 from django.conf.urls import url
 from oauth2_provider import views as oauth2_views
+from .oauth2_views import ApplicationRegistration
 from apps.oidc import views as oidc_views
 from apps.home.views import authenticated_home, user_search, user_profile
 
@@ -45,7 +46,7 @@ oauth2_management_urlpatterns = [
         oauth2_views.ApplicationList.as_view(),
         name="list"),
     url(r"^applications/register/$",
-        oauth2_views.ApplicationRegistration.as_view(),
+        ApplicationRegistration.as_view(),
         name="register"),
     url(r"^applications/(?P<pk>[\w-]+)/$",
         oauth2_views.ApplicationDetail.as_view(),


### PR DESCRIPTION
- limits response types to "code"
- limits grant types to "authorization-code" and "refresh-token"

Closes #80