### PR TITLE
Use Django Method T Set User's Password Through API

### DIFF
--- a/apps/api/views/user.py
+++ b/apps/api/views/user.py
@@ -55,6 +55,10 @@ class UserSerializer(serializers.Serializer):
         user_data = validated_data.get('user', {})
         user = User.objects.create(**user_data)
 
+        # We must use the set_password() method to set the user's password
+        user.set_password(user_data['password'])
+        user.save()
+
         validated_data['user'] = user
         return UserProfile.objects.create(**validated_data)
 
@@ -62,6 +66,11 @@ class UserSerializer(serializers.Serializer):
         user_data = validated_data.pop('user', {})
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
+
+        # If the user's password is being set, we must use the set_password() method to set it
+        if user_data.get('password'):
+            instance.user.set_password(user_data['password'])
+            instance.user.save()
 
         instance.save()
 


### PR DESCRIPTION
Creating or updating a user through the user API endpoint now uses the `User.set_password()` method to set the user's password. Previously, setting the password would set it to the exact value in the request data, which would fail when using `User.check_password()`.